### PR TITLE
Add gits command

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,14 @@
+name: Pull Request
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      - name: Build
+        shell: pwsh
+        run: ./build.ps1 -Task Test -Bootstrap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[unreleased]: https://github.com/lancra/pwsh/compare/v0.1.0-preview-0...HEAD

--- a/build.ps1
+++ b/build.ps1
@@ -159,7 +159,11 @@ function Analyze {
     [CmdletBinding()]
     param()
     process {
-        $analysis = Invoke-ScriptAnalyzer -Path $sut -Recurse -Verbose:$false
+        $analysisSettings = @{
+            ExcludeRules = @('PSAvoidUsingWriteHost')
+        }
+
+        $analysis = Invoke-ScriptAnalyzer -Path $sut -Recurse -Settings $analysisSettings -Verbose:$false
         $errors = $analysis | Where-Object { $_.Severity -eq 'Error' }
         $warnings = $analysis | Where-Object { $_.Severity -eq 'Warning' }
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,217 @@
+#requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    # Build task(s) to execute
+    [ValidateSet('Init', 'Clean', 'Build', 'Analyze', 'Pester', 'Test')]
+    [string]$Task = 'Test',
+
+    # Bootstrap dependencies
+    [switch]$Bootstrap
+)
+
+$sut = Join-Path -Path $PSScriptRoot -ChildPath 'src'
+$manifestPath = Join-Path -Path $sut -ChildPath 'Lance.psd1'
+$version = (Import-PowerShellDataFile -Path $manifestPath).ModuleVersion
+$artifactsDirectory = Join-Path -Path $PSScriptRoot -ChildPath 'artifacts'
+$artifactsModuleDirectory = Join-Path -Path $artifactsDirectory -ChildPath 'Lance'
+$artifactsModuleVersionDirectory = Join-Path -Path $artifactsModuleDirectory -ChildPath $version
+$artifactsManifest = Join-Path -Path $artifactsModuleVersionDirectory -ChildPath 'Lance.psd1'
+
+$PSDefaultParameterValues = @{
+    'Get-Module:Verbose' = $false
+    'Remove-Module:Verbose' = $false
+    'Import-Module:Verbose' = $false
+}
+
+if ($Bootstrap) {
+    Get-PackageProvider -Name NuGet -ForceBootstrap | Out-Null
+    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+    if (-not (Get-Module -Name PSDepend -ListAvailable)) {
+        Install-Module -Name PSDepend -Repository PSGallery -Scope CurrentUser -Force
+    }
+
+    Import-Module -Name PSDepend -Verbose:$false
+    Invoke-PSDepend -Path './requirements.psd1' -Install -Import -Force -WarningAction SilentlyContinue
+}
+
+# Taken with love from Jaykul @ https://gist.github.com/Jaykul/e0c08be051bed56d62474ae12b9b1b8a
+class DependsOn : System.Attribute {
+    [string[]]$Name
+
+    DependsOn([string[]]$name) {
+        $this.Name = $name
+    }
+}
+function Invoke-Step {
+    <#
+        .SYNOPSIS
+            Runs a command, taking care to run it's dependencies first
+        .DESCRIPTION
+            Invoke-Step supports the [DependsOn("...")] attribute to allow you to write tasks or build steps that take dependencies on other tasks completing first.
+
+            When you invoke a step, dependencies are run first, recursively. The algorithm for this is depth-first and *very* naive. Don't build cycles!
+       .EXAMPLE
+            function init {
+                param()
+                Write-Information "INITIALIZING build variables"
+            }
+
+            function update {
+                [DependsOn("init")]param()
+                Write-Information "UPDATING dependencies"
+            }
+
+            function build {
+                [DependsOn(("update","init"))]param()
+                Write-Information "BUILDING: $ModuleName from $Path"
+            }
+
+            Invoke-Step build -InformationAction continue
+
+            Defines three steps with dependencies, and invokes the "build" step.
+            Results in this output:
+
+            Invoking Step: init
+            Invoking Step: update
+            Invoking Step: build
+
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$Step,
+        [string]$Script
+    )
+
+    begin {
+        # Source Build Scripts, if any
+        if ($Script) {
+            . $Script
+        }
+
+        # Don't reset on nested calls
+        if (((Get-PSCallStack).Command -eq 'Invoke-Step').Count -eq 1) {
+            $script:InvokedSteps = @()
+        }
+    }
+
+    end {
+        if ($stepCommand = Get-Command -Name $Step -CommandType Function) {
+
+            $dependencies = $stepCommand.ScriptBlock.Attributes.Where{$_.TypeId.Name -eq 'DependsOn'}.Name
+            foreach ($dependency in $dependencies) {
+                if ($dependency -notin $script:InvokedSteps) {
+                    Invoke-Step -Step $dependency
+                }
+            }
+
+            if ($Step -notin $script:InvokedSteps) {
+                Write-Host "Invoking Step: $Step" -ForegroundColor Cyan
+                try {
+                    & $stepCommand
+                    $script:InvokedSteps += $Step
+                } catch {
+                    throw $_
+                }
+            }
+        } else {
+            throw "Could not find step [$Step]"
+        }
+    }
+}
+
+function Init {
+    [CmdletBinding()]
+    param()
+    process {
+        Remove-Module -Name Lance -Force -ErrorAction SilentlyContinue
+        Set-BuildEnvironment -Force
+    }
+}
+
+function Clean {
+    [DependsOn('Init')]
+    [CmdletBinding()]
+    param()
+    process {
+        if (Test-Path -Path $artifactsModuleVersionDirectory) {
+            Remove-Item -Path $artifactsModuleVersionDirectory -Recurse -Force | Out-Null
+        }
+    }
+}
+
+function Build {
+    [DependsOn('Clean')]
+    [CmdletBinding()]
+    param()
+    process {
+        if (-not (Test-Path -Path $artifactsDirectory)) {
+            New-Item -Path $artifactsDirectory -ItemType Directory | Out-Null
+        }
+
+        New-Item -Path $artifactsModuleVersionDirectory -ItemType Directory | Out-Null
+        Copy-Item -Path (Join-Path -Path $sut -ChildPath *) -Destination $artifactsModuleVersionDirectory -Recurse
+    }
+}
+
+function Analyze {
+    [DependsOn('Init')]
+    [CmdletBinding()]
+    param()
+    process {
+        $analysis = Invoke-ScriptAnalyzer -Path $sut -Recurse -Verbose:$false
+        $errors = $analysis | Where-Object { $_.Severity -eq 'Error' }
+        $warnings = $analysis | Where-Object { $_.Severity -eq 'Warning' }
+
+        if (($errors.Count -eq 0) -and ($warnings.Count -eq 0)) {
+            'PSScriptAnalyzer passed without errors or warnings'
+        }
+
+        if (@($errors).Count -gt 0) {
+            Write-Error -Message 'One or more Script Analyzer errors were found. Build cannot continue!'
+            $errors | Format-Table -AutoSize
+        }
+
+        if (@($warnings).Count -gt 0) {
+            Write-Warning -Message 'One or more Script Analyzer warnings were found. These should be corrected.'
+            $warnings | Format-Table -AutoSize
+        }
+    }
+}
+
+function Pester {
+    [DependsOn('Init')]
+    [CmdletBinding()]
+    param()
+    process {
+        Import-Module -Name $artifactsManifest -Force
+
+        $pesterParams = @{
+            Path = './tests'
+            Output = 'Detailed'
+            PassThru = $true
+        }
+
+        $testResults = Invoke-Pester @pesterParams
+        if ($testResults.FailedCount -gt 0) {
+            throw "$($testResults.FailedCount) tests failed!"
+        }
+    }
+}
+
+function Test {
+    [DependsOn(('Build', 'Analyze', 'Pester'))]
+    [CmdletBinding()]
+    param()
+    process {}
+}
+
+try {
+    Push-Location
+    Invoke-Step -Step $Task
+} catch {
+    throw $_
+    exit 1
+} finally {
+    Pop-Location
+}

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -1,0 +1,9 @@
+@{
+    PSDependOptions = @{
+        Repository = 'PSGallery'
+        Target = 'CurrentUser'
+    }
+    BuildHelpers = '2.0.16'
+    Pester = '5.5.0'
+    PSScriptAnalyzer = '1.21.0'
+}

--- a/src/Lance.psd1
+++ b/src/Lance.psd1
@@ -5,7 +5,9 @@
     Author = 'Lance Craig'
     PowerShellVersion = '7.0'
     Description = "Lance's general-use scripts."
-    FunctionsToExport = @()
+    FunctionsToExport = @(
+        'Write-GitRepositoryDetail'
+    )
     VariablesToExport = 'Lance'
     PrivateData = @{
         PSData = @{

--- a/src/Lance.psd1
+++ b/src/Lance.psd1
@@ -1,0 +1,18 @@
+@{
+    RootModule = 'Lance.psm1'
+    ModuleVersion = '0.1.0'
+    Guid = '4cb79175-aa10-4939-a89c-92ac68caf0d9'
+    Author = 'Lance Craig'
+    PowerShellVersion = '7.0'
+    Description = "Lance's general-use scripts."
+    FunctionsToExport = @()
+    VariablesToExport = 'Lance'
+    PrivateData = @{
+        PSData = @{
+            Prerelease = 'preview0'
+            ReleaseNotes = 'https://raw.githubusercontent.com/lancra/pwsh/main/CHANGELOG.md'
+            LicenseUri = 'https://raw.githubusercontent.com/lancra/pwsh/main/LICENSE'
+            ProjectUri = 'https://github.com/lancra/pwsh'
+        }
+    }
+}

--- a/src/Lance.psd1
+++ b/src/Lance.psd1
@@ -6,6 +6,7 @@
     PowerShellVersion = '7.0'
     Description = "Lance's general-use scripts."
     FunctionsToExport = @(
+        'Invoke-SubDirectoryGitCommand',
         'Write-GitRepositoryDetail'
     )
     VariablesToExport = 'Lance'

--- a/src/Lance.psd1
+++ b/src/Lance.psd1
@@ -12,7 +12,7 @@
     VariablesToExport = 'Lance'
     PrivateData = @{
         PSData = @{
-            Prerelease = 'preview0'
+            Prerelease = 'preview1'
             ReleaseNotes = 'https://raw.githubusercontent.com/lancra/pwsh/main/CHANGELOG.md'
             LicenseUri = 'https://raw.githubusercontent.com/lancra/pwsh/main/LICENSE'
             ProjectUri = 'https://github.com/lancra/pwsh'

--- a/src/Lance.psm1
+++ b/src/Lance.psm1
@@ -1,0 +1,34 @@
+#Requires -Version 2.0
+
+if ($PSVersionTable.PSVersion.Major -ge 3) {
+    $script:IgnoreError = 'Ignore'
+} else {
+    $script:IgnoreError = 'SilentlyContinue'
+}
+
+$script:nl = [System.Environment]::NewLine
+
+# Dot source public/private functions
+$dotSourceParams = @{
+    Filter = '*.ps1'
+    Recurse = $true
+    ErrorAction = 'Stop'
+}
+
+$public = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'public') @dotSourceParams)
+$private = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'private/*.ps1') @dotSourceParams)
+foreach ($import in @($public + $private)) {
+    try {
+        . $import.FullName
+    } catch {
+        throw "Unable to dot source [$($import.FullName)]"
+    }
+}
+
+$scriptDirectory = Split-Path $MyInvocation.MyCommand.Path
+$manifestPath = Join-Path $scriptDirectory Lance.psd1
+Test-ModuleManifest -Path $manifestPath -WarningAction SilentlyContinue
+
+$script:Lance = @{}
+
+Export-ModuleMember -Function $public.BaseName -Variable Lance

--- a/src/private/OutputSegment.ps1
+++ b/src/private/OutputSegment.ps1
@@ -1,0 +1,14 @@
+class OutputSegment {
+    [string]$Text
+    [System.ConsoleColor]$ForegroundColor
+
+    OutputSegment([string]$text) {
+        $this.Text = $text
+        $this.ForegroundColor = [System.Console]::ForegroundColor
+    }
+
+    OutputSegment([string]$text, [System.ConsoleColor]$foregroundColor) {
+        $this.Text = $text
+        $this.ForegroundColor = $foregroundColor
+    }
+}

--- a/src/private/Write-HostSegment.ps1
+++ b/src/private/Write-HostSegment.ps1
@@ -1,0 +1,21 @@
+function Write-HostSegment {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [OutputSegment[]]$Segments
+    )
+    process {
+        $segmentCounter = 0
+        $Segments |
+            ForEach-Object {
+                $segmentCounter++
+                $isLastSegment = $segmentCounter -eq $Segments.Length
+
+                Write-Host -Object $_.Text -ForegroundColor $_.ForegroundColor -NoNewline
+
+                if ($isLastSegment) {
+                    Write-Host ''
+                }
+            }
+    }
+}

--- a/src/public/Invoke-SubDirectoryGitCommand.ps1
+++ b/src/public/Invoke-SubDirectoryGitCommand.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+Invokes a Git command against all sub-directories within a provided path.
+
+.DESCRIPTION
+For all of the child directories from the provided path, this executes the
+provided Git command using the "-C" flag, which prevents the need to change
+directories.
+
+.PARAMETER Command
+The Git command to execute, excluding the Git executable.
+
+.PARAMETER Path
+The parent directory to find all child Git repositories from.
+
+.PARAMETER NoHead
+Disables writing the current head to the host via the Write-GitRepositoryDetail
+function.
+
+.PARAMETER NoAheadBehind
+Disables writing the remote ahead/behind to the host via the
+Write-GitRepositoryDetail function.
+
+.EXAMPLE
+Invoke-SubDirectoryGitCommand -Command {fetch} -Path C:\Projects\git
+
+.EXAMPLE
+Invoke-SubDirectoryGitCommand -Command {config --get commit.gpgSign} `
+    -Path C:\Projects\git -NoHead -NoAheadBehind
+#>
+function Invoke-SubDirectoryGitCommand {
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSReviewUnusedParameter',
+        'Command',
+        Justification = 'False positive since rule does not scan child scopes')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSReviewUnusedParameter',
+        'NoHead',
+        Justification = 'False positive since rule does not scan child scopes')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSReviewUnusedParameter',
+        'NoAheadBehind',
+        Justification = 'False positive since rule does not scan child scopes')]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [scriptblock]$Command,
+        [Parameter()]
+        [string]$Path = '.',
+        [switch]$NoHead,
+        [switch]$NoAheadBehind
+    )
+    process {
+        Get-ChildItem -Path $Path -Directory |
+            ForEach-Object {
+                Write-GitRepositoryDetail -Path $_.FullName -NoHead:$NoHead -NoAheadBehind:$NoAheadBehind
+
+                $trimmedCommand = $Command.ToString().Trim()
+                if ($trimmedCommand -like 'branch-current*' -and -not $NoHead) {
+                    # Do not show the current branch via the provided command since it is displayed along with the directory name.
+                    return
+                }
+
+                $executedCommand = "git -C '$($_.FullName)' $trimmedCommand"
+                Invoke-Command -ScriptBlock ([scriptblock]::Create($executedCommand))
+            }
+    }
+}
+
+New-Alias -Name gits -Value Invoke-SubDirectoryGitCommand
+Export-ModuleMember -Alias gits

--- a/src/public/Write-GitRepositoryDetail.ps1
+++ b/src/public/Write-GitRepositoryDetail.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+Writes the name of a repository with some optional details.
+
+.DESCRIPTION
+Uses the name of the directory from the filesystem to name the repository. Then,
+unless disabled, it uses the branch status from Git to write the current head
+and the ahead/behind to the associated remote.
+
+.PARAMETER Path
+The filesystem path for the repository. The current directory is used if none is
+provided.
+
+.PARAMETER NoHead
+Disables writing the current head to the host.
+
+.PARAMETER NoAheadBehind
+Disables writing the remote ahead/behind to the host.
+
+.EXAMPLE
+Write-GitRepositoryDetail -Path C:\Projects\git
+git (seen +0 -0)
+
+.EXAMPLE
+Write-GitRepositoryDetail -Path C:\Projects\git -NoHead
+git (+0 -0)
+
+.EXAMPLE
+Write-GitRepositoryDetail -Path C:\Projects\git -NoAheadBehind
+git (seen)
+
+.EXAMPLE
+Write-GitRepositoryDetail -Path C:\Projects\git -NoHead -NoAheadBehind
+git:
+#>
+function Write-GitRepositoryDetail {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Path = '.',
+        [switch]$NoHead,
+        [switch]$NoAheadBehind
+    )
+    begin {
+        class BranchStatus {
+            [string]$Head
+            [string]$Ahead
+            [string]$Behind
+
+            BranchStatus([string[]]$commandOutput) {
+                $statusHeaderMatches = $commandOutput |
+                    Select-String -Pattern '# ([^\s]+) (.*)' |
+                    Select-Object -ExpandProperty Matches
+
+                $headStatusHeaderMatch = $statusHeaderMatches |
+                    Where-Object { $_.Groups[1].Value -eq 'branch.head' } |
+                    Select-Object -First 1
+                $this.Head = $headStatusHeaderMatch.Groups[2].Value
+
+                $aheadBehindStatusHeaderMatch = $statusHeaderMatches |
+                    Where-Object { $_.Groups[1].Value -eq 'branch.ab' } |
+                    Select-Object -First 1
+                if ($aheadBehindStatusHeaderMatch) {
+                    $aheadBehindParts = $aheadBehindStatusHeaderMatch.Groups[2].Value -split ' '
+                    $this.Ahead = $aheadBehindParts[0]
+                    $this.Behind = $aheadBehindParts[1]
+                }
+            }
+        }
+    }
+    process {
+        # Any Git commands should be executed before printing the directory since the opposite order introducing a stuttering behavior
+        # when printing.
+        $script:branchStatus = $null
+        if (-not $NoHead -or -not $NoAheadBehind) {
+            $branchStatusCommand = "git -C '$Path' status --branch --porcelain=2"
+            $branchStatusOutput = Invoke-Command -ScriptBlock ([scriptblock]::Create($branchStatusCommand))
+            $script:branchStatus = [BranchStatus]::new($branchStatusOutput)
+        }
+
+        $outputSegments = [System.Collections.Generic.List[OutputSegment]]::new()
+
+        $repository = Split-Path -Path $Path -Leaf
+        $outputSegments.Add([OutputSegment]::new($repository, 'Yellow'))
+
+        if ($script:branchStatus) {
+            $outputSegments.Add([OutputSegment]::new(' ('))
+
+            $showHead = -not $NoHead -and $script:branchStatus.Head
+            if ($showHead) {
+                $outputSegments.Add([OutputSegment]::new($script:branchStatus.Head, 'Blue'))
+            }
+
+            $showAheadBehind = -not $NoAheadBehind -and ($script:branchStatus.Ahead -or $script:branchStatus.Behind)
+            if ($showAheadBehind) {
+                $ahead = $script:branchStatus.Ahead
+                if ($showHead) {
+                    $ahead = " $ahead"
+                }
+
+                $outputSegments.Add([OutputSegment]::new($ahead, 'Green'))
+                $outputSegments.Add([OutputSegment]::new(" $($script:branchStatus.Behind)", 'Red'))
+            }
+
+            $outputSegments.Add([OutputSegment]::new(')'))
+        } else {
+            $outputSegments.Add([OutputSegment]::new(':'))
+        }
+
+        Write-HostSegment -Segments $outputSegments.ToArray()
+    }
+}

--- a/tests/Manifest.Tests.ps1
+++ b/tests/Manifest.Tests.ps1
@@ -5,7 +5,14 @@ BeforeAll {
     $artifactsModuleDirectory = Join-Path -Path $artifactsDirectory -ChildPath $env:BHProjectName
     $artifactsModuleVersionDirectory = Join-Path -Path $artifactsModuleDirectory -ChildPath $manifest.ModuleVersion
     $artifactsManifestPath = Join-Path -Path $artifactsModuleVersionDirectory -Child "$($moduleName).psd1"
-    $script:manifestData = Test-ModuleManifest -Path $artifactsManifestPath -Verbose:$false -ErrorAction Stop -WarningAction SilentlyContinue
+
+    $manifestDataParams = @{
+        ErrorAction = 'Stop'
+        Path = $artifactsManifestPath
+        Verbose = $false
+        WarningAction = 'SilentlyContinue'
+    }
+    $script:manifestData = Test-ModuleManifest @manifestDataParams
 
     $changelogPath = Join-Path -Path $env:BHProjectPath -Child 'CHANGELOG.md'
     $script:changelogVersion = Get-Content $changelogPath |

--- a/tests/Manifest.Tests.ps1
+++ b/tests/Manifest.Tests.ps1
@@ -1,0 +1,86 @@
+BeforeAll {
+    $moduleName = $env:BHProjectName
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $artifactsDirectory = Join-Path -Path $ENV:BHProjectPath -ChildPath 'artifacts'
+    $artifactsModuleDirectory = Join-Path -Path $artifactsDirectory -ChildPath $env:BHProjectName
+    $artifactsModuleVersionDirectory = Join-Path -Path $artifactsModuleDirectory -ChildPath $manifest.ModuleVersion
+    $artifactsManifestPath = Join-Path -Path $artifactsModuleVersionDirectory -Child "$($moduleName).psd1"
+    $script:manifestData = Test-ModuleManifest -Path $artifactsManifestPath -Verbose:$false -ErrorAction Stop -WarningAction SilentlyContinue
+
+    $changelogPath = Join-Path -Path $env:BHProjectPath -Child 'CHANGELOG.md'
+    $script:changelogVersion = Get-Content $changelogPath |
+        ForEach-Object {
+            if ($_ -match '^##\s\[(?<Version>(\d+\.){1,3}\d+)\]') {
+                $script:changelogVersion = $matches.Version
+                break
+            }
+        }
+
+    $script:manifest = $null
+}
+
+Describe 'Module Manifest' {
+
+    Context 'Validation' {
+
+        It 'Has a valid manifest' {
+            $script:manifestData | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has a valid name in the manifest' {
+            $script:manifestData.Name | Should -Be $moduleName
+        }
+
+        It 'Has a valid root module' {
+            $script:manifestData.RootModule | Should -Be "$($moduleName).psm1"
+        }
+
+        It 'Has a valid version in the manifest' {
+            $script:manifestData.Version -as [Version] | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has a valid description' {
+            $script:manifestData.Description | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has a valid author' {
+            $script:manifestData.Author | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Has a valid guid' {
+            {[guid]::Parse($script:manifestData.Guid)} | Should -Not -Throw
+        }
+
+        # TODO: Enable these before first release.
+        It 'Has a valid version in the changelog' -Skip {
+            $script:changelogVersion | Should -Not -BeNullOrEmpty
+            $script:changelogVersion -as [Version] | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Changelog and manifest versions match' -Skip {
+            $script:changelogVersion -as [Version] | Should -Be ( $script:manifestData.Version -as [Version] )
+        }
+    }
+}
+
+Describe 'Git Tags' -Skip {
+    BeforeAll {
+        $script:gitTagVersion = $null
+        if (Get-Command git -CommandType Application -ErrorAction SilentlyContinue) {
+            # Aliased on my machine as "tags-latest".
+            $tagMessage = git log --tags --decorate --oneline --simplify-by-decoration -1 --format='%(describe:tags)'
+            if ($tagMessage -and $tagMessage[0] -eq 'v') {
+                $script:gitTagVersion = $tagMessage
+            }
+        }
+    }
+
+    It 'Has a valid version tag' {
+        $script:gitTagVersion | Should -Not -BeNullOrEmpty
+        $script:gitTagVersion -as [Version] | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Tag and manifest versions match' {
+        $script:manifestData.Version -as [Version] | Should -Be ( $script:gitTagVersion -as [Version])
+    }
+}

--- a/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
+++ b/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
@@ -1,0 +1,86 @@
+BeforeAll {
+    function New-TemporaryDirectory {
+        $path = Join-Path -Path $env:Temp -ChildPath (New-Guid).Guid
+        New-Item -ItemType Directory -Path $path > $null
+        $path
+    }
+}
+
+Describe 'Command Execution' {
+    Context 'On Each Child Directory' {
+        BeforeEach {
+            $basePath = New-TemporaryDirectory
+
+            $fooPath = Join-Path -Path $basePath -ChildPath 'foo'
+            New-Item -ItemType Directory -Path $fooPath
+
+            $barPath = Join-Path -Path $basePath -ChildPath 'bar'
+            New-Item -ItemType Directory -Path $barPath
+
+            $bazPath = Join-Path -Path $basePath -ChildPath 'baz'
+            New-Item -ItemType Directory -Path $bazPath
+
+            Mock Write-GitRepositoryDetail -ModuleName Lance
+            Mock git -ModuleName Lance
+
+            Invoke-SubDirectoryGitCommand -Command {fetch} -Path $basePath -NoAheadBehind
+        }
+
+        It 'Writes repository detail' {
+            Should -Invoke -Command Write-GitRepositoryDetail -ModuleName 'Lance' -ParameterFilter {
+                $Path -eq $fooPath -and
+                -not $NoHead -and
+                $NoAheadBehind
+            }
+
+            Should -Invoke -Command Write-GitRepositoryDetail -ModuleName 'Lance' -ParameterFilter {
+                $Path -eq $barPath -and
+                -not $NoHead -and
+                $NoAheadBehind
+            }
+
+            Should -Invoke -Command Write-GitRepositoryDetail -ModuleName 'Lance' -ParameterFilter {
+                $Path -eq $bazPath -and
+                -not $NoHead -and
+                $NoAheadBehind
+            }
+        }
+
+        It 'Invokes Git command' {
+            Should -Invoke -CommandName 'git' -ModuleName 'Lance' -ParameterFilter { "$args" -eq "-C $fooPath fetch" }
+            Should -Invoke -CommandName 'git' -ModuleName 'Lance' -ParameterFilter { "$args" -eq "-C $barPath fetch" }
+            Should -Invoke -CommandName 'git' -ModuleName 'Lance' -ParameterFilter { "$args" -eq "-C $bazPath fetch" }
+        }
+    }
+
+    Context 'Command-Specific Logic' {
+        BeforeEach {
+            $basePath = New-TemporaryDirectory
+
+            $childPath = Join-Path -Path $basePath -ChildPath 'child'
+            New-Item -ItemType Directory -Path $childPath
+
+            Mock Write-GitRepositoryDetail -ModuleName Lance
+            Mock git -ModuleName Lance
+        }
+
+        It 'Trims provided command' {
+            Invoke-SubDirectoryGitCommand -Command {  pull  } -Path $basePath
+            Should -Invoke -CommandName 'git' -ModuleName 'Lance' -ParameterFilter { "$args" -eq "-C $childPath pull" }
+        }
+
+        It 'Skips current branch alias when head is shown' {
+            Invoke-SubDirectoryGitCommand -Command { branch-current } -Path $basePath
+            Should -Not -Invoke -CommandName 'git' -ModuleName 'Lance' -ParameterFilter { "$args" -eq "-C $childPath branch-current" }
+        }
+
+        It 'Executes current branch alias when head is not shown' {
+            Invoke-SubDirectoryGitCommand -Command { branch-current } -Path $basePath -NoHead
+            Should -Invoke -CommandName 'git' -ModuleName 'Lance' -ParameterFilter { "$args" -eq "-C $childPath branch-current" }
+        }
+    }
+
+    AfterEach {
+        Remove-Item -Path $basePath -Recurse
+    }
+}

--- a/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
+++ b/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
@@ -1,6 +1,6 @@
 BeforeAll {
     function New-TemporaryDirectory {
-        $path = Join-Path -Path $env:Temp -ChildPath (New-Guid).Guid
+        $path = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (New-Guid).Guid
         New-Item -ItemType Directory -Path $path > $null
         $path
     }

--- a/tests/public/Write-GitRepositoryDetail.Tests.ps1
+++ b/tests/public/Write-GitRepositoryDetail.Tests.ps1
@@ -1,13 +1,15 @@
 BeforeAll {
     function New-TemporaryDirectory {
-        $path = Join-Path -Path $env:Temp -ChildPath (New-Guid).Guid
+        $path = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (New-Guid).Guid
         New-Item -ItemType Directory -Path $path > $null
         $path
     }
 
     # Setup remote repository.
     $remoteTemplatePath = New-TemporaryDirectory
-    git -C $remoteTemplatePath init
+    git -C $remoteTemplatePath init --initial-branch=main
+    git -C $remoteTemplatePath config --local user.email "testuser@example.org"
+    git -C $remoteTemplatePath config --local user.name "Test User"
 
     'foo' > (Join-Path -Path $remoteTemplatePath -ChildPath 'foo.txt')
     git -C $remoteTemplatePath add 'foo.txt'
@@ -26,6 +28,8 @@ Describe 'Expected Output' {
 
         $localPath = New-TemporaryDirectory
         git clone "$remotePath/.git" $localPath *> $null
+        git -C $localPath config --local user.email "testuser@example.org"
+        git -C $localPath config --local user.name "Test User"
 
         Mock Write-Host -ModuleName Lance
     }

--- a/tests/public/Write-GitRepositoryDetail.Tests.ps1
+++ b/tests/public/Write-GitRepositoryDetail.Tests.ps1
@@ -1,0 +1,313 @@
+BeforeAll {
+    function New-TemporaryDirectory {
+        $path = Join-Path -Path $env:Temp -ChildPath (New-Guid).Guid
+        New-Item -ItemType Directory -Path $path > $null
+        $path
+    }
+
+    # Setup remote repository.
+    $remoteTemplatePath = New-TemporaryDirectory
+    git -C $remoteTemplatePath init
+
+    'foo' > (Join-Path -Path $remoteTemplatePath -ChildPath 'foo.txt')
+    git -C $remoteTemplatePath add 'foo.txt'
+    git -C $remoteTemplatePath commit -m 'Add foo'
+
+    'bar' > (Join-Path -Path $remoteTemplatePath -ChildPath 'bar.txt')
+    git -C $remoteTemplatePath add 'bar.txt'
+    git -C $remoteTemplatePath commit -m 'Add bar'
+}
+
+Describe 'Expected Output' {
+    BeforeEach {
+        $remotePath = New-TemporaryDirectory
+        $remoteTemplateCopyPath = Join-Path -Path $remoteTemplatePath -ChildPath '*'
+        Copy-Item -Path $remoteTemplateCopyPath -Destination $remotePath -Recurse -Force
+
+        $localPath = New-TemporaryDirectory
+        git clone "$remotePath/.git" $localPath *> $null
+
+        Mock Write-Host -ModuleName Lance
+    }
+
+    Context 'Default Repository' {
+        It 'Shows repository, head, and ahead/behind' {
+            Write-GitRepositoryDetail -Path $localPath
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'main' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+
+        It 'Excludes head when specified' {
+            Write-GitRepositoryDetail -Path $localPath -NoHead
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'main' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq '+0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+
+        It 'Excludes ahead/behind when specified' {
+            Write-GitRepositoryDetail -Path $localPath -NoAheadBehind
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'main' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+
+        It 'Excludes head and ahead/behind when specified' {
+            Write-GitRepositoryDetail -Path $localPath -NoHead -NoAheadBehind
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ':' -and $NoNewline -eq $true }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'main' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+    }
+
+    Context 'Modified Local' {
+        It 'Shows correct head' {
+            git -C $localPath switch -c 'fancy-new-branch' *> $null
+            git -C $localPath push -u origin fancy-new-branch *> $null
+
+            Write-GitRepositoryDetail -Path $localPath
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'fancy-new-branch' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+
+        It 'Shows detached head correctly' {
+            $firstCommitId = (git -C $localPath rev-list --max-parents=0 HEAD)
+            git -C $localPath switch --detach $firstCommitId *> $null
+
+            Write-GitRepositoryDetail -Path $localPath
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq '(detached)' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+
+        It 'Excludes ahead/behind for local branch' {
+            git -C $localPath switch -c 'fancy-new-branch' *> $null
+
+            Write-GitRepositoryDetail -Path $localPath
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'fancy-new-branch' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+
+        It 'Shows correct ahead' {
+            'baz' > (Join-Path -Path $localPath -ChildPath 'baz.txt')
+            git -C $localPath add 'baz.txt'
+            git -C $localPath commit -m 'Add baz'
+
+            'qux' > (Join-Path -Path $localPath -ChildPath 'qux.txt')
+            git -C $localPath add 'qux.txt'
+            git -C $localPath commit -m 'Add qux'
+
+            Write-GitRepositoryDetail -Path $localPath
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'main' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +2' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -0' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+    }
+
+    Context 'Modified Remote' {
+        It 'Shows correct behind' {
+            'baz' > (Join-Path -Path $remotePath -ChildPath 'baz.txt')
+            git -C $remotePath add 'baz.txt'
+            git -C $remotePath commit -m 'Add baz'
+
+            git -C $localPath fetch *> $null
+
+            Write-GitRepositoryDetail -Path $localPath
+
+            $expectedRepository = Split-Path -Path $localPath -Leaf
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq $expectedRepository -and
+                $ForegroundColor -eq 'Yellow'
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ' (' -and $NoNewline -eq $true }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq 'main' -and
+                $ForegroundColor -eq 'Blue' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' +0' -and
+                $ForegroundColor -eq 'Green' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter {
+                $Object -eq ' -1' -and
+                $ForegroundColor -eq 'Red' -and
+                $NoNewline -eq $true
+            }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq ')' -and $NoNewline -eq $true }
+        }
+    }
+
+    AfterEach {
+        Remove-Item -Path $remotePath -Recurse -Force > $null
+        Remove-Item -Path $localPath -Recurse -Force > $null
+    }
+}
+
+AfterAll {
+    Remove-Item -Path $remoteTemplatePath -Recurse -Force > $null
+}


### PR DESCRIPTION
- Add the `Invoke-SubDirectoryGitCommand` function, aliased as `gits`, to allow for easy execution of Git commands in multiple directories.
- Add the `Write-GitRepositoryDetail` function to display repository information from the local filesystem and Git status details.