### PR TITLE
Add superclean command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Add Invoke-SubDirectoryGitCommand function (#1).
+- Add Write-GitRepositoryDetail function (#1).
 
 [unreleased]: https://github.com/lancra/pwsh/compare/v0.1.0-preview-0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Invoke-SubDirectoryGitCommand function (#1).
 - Add Write-GitRepositoryDetail function (#1).
+- Add Remove-BuildArtifact function (#2).
 
 [unreleased]: https://github.com/lancra/pwsh/compare/v0.1.0-preview-0...HEAD

--- a/src/Lance.psd1
+++ b/src/Lance.psd1
@@ -5,14 +5,19 @@
     Author = 'Lance Craig'
     PowerShellVersion = '7.0'
     Description = "Lance's general-use scripts."
+    AliasesToExport = @(
+        'gits',
+        'superclean'
+    )
     FunctionsToExport = @(
         'Invoke-SubDirectoryGitCommand',
+        'Remove-BuildArtifact',
         'Write-GitRepositoryDetail'
     )
     VariablesToExport = 'Lance'
     PrivateData = @{
         PSData = @{
-            Prerelease = 'preview1'
+            Prerelease = 'preview2'
             ReleaseNotes = 'https://raw.githubusercontent.com/lancra/pwsh/main/CHANGELOG.md'
             LicenseUri = 'https://raw.githubusercontent.com/lancra/pwsh/main/LICENSE'
             ProjectUri = 'https://github.com/lancra/pwsh'

--- a/src/public/Remove-BuildArtifact.ps1
+++ b/src/public/Remove-BuildArtifact.ps1
@@ -1,0 +1,24 @@
+function Remove-BuildArtifact {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [string]$Path = '.'
+    )
+    begin {
+        $targetFolderNames = @('artifacts', 'bin', 'obj')
+    }
+    process {
+        Get-ChildItem -Path $Path -Include $targetFolderNames -Recurse |
+            ForEach-Object {
+                $path = $_.FullName
+                if (-not $WhatIfPreference) {
+                    Write-Host "Removing $path"
+                }
+
+                Remove-Item -Path $path -Force -Recurse
+            }
+    }
+}
+
+New-Alias -Name superclean -Value Remove-BuildArtifact
+Export-ModuleMember -Alias superclean

--- a/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
+++ b/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
@@ -1,9 +1,5 @@
 BeforeAll {
-    function New-TemporaryDirectory {
-        $path = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (New-Guid).Guid
-        New-Item -ItemType Directory -Path $path > $null
-        $path
-    }
+    . $PSScriptRoot/../testing/New-TemporaryDirectory.ps1
 }
 
 Describe 'Command Execution' {

--- a/tests/public/Remove-BuildArtifact.Tests.ps1
+++ b/tests/public/Remove-BuildArtifact.Tests.ps1
@@ -1,0 +1,197 @@
+BeforeAll {
+    . $PSScriptRoot/../testing/New-TemporaryDirectory.ps1
+}
+
+Describe 'Deletion' {
+    Context 'Artifacts' {
+        BeforeEach {
+            $rootPath = New-TemporaryDirectory
+            $rootArtifactsPath = Join-Path -Path $rootPath -ChildPath 'artifacts'
+
+            $fooPath = Join-Path -Path $rootPath -ChildPath 'foo'
+            $fooArtifactsPath = Join-Path -Path $fooPath -ChildPath 'artifacts'
+
+            $barPath = Join-Path -Path $rootPath -ChildPath 'bar'
+            $barArtifactsPath = Join-Path -Path $barPath -ChildPath 'artifacts'
+
+            New-Item -ItemType 'File' -Path (Join-Path -Path $rootArtifactsPath -ChildPath '1.txt') -Force
+            New-Item -ItemType 'File' -Path (Join-Path -Path $fooArtifactsPath -ChildPath '2.txt') -Force
+            New-Item -ItemType 'File' -Path (Join-Path -Path $barArtifactsPath -ChildPath '3.txt') -Force
+
+            $remainingRootFilePath = Join-Path -Path $rootPath -ChildPath '4.txt'
+            $remainingFooFilePath = Join-Path -Path $fooPath -ChildPath '5.txt'
+            $remainingBarFilePath = Join-Path -Path $barPath -ChildPath '6.txt'
+            New-Item -ItemType 'File' -Path $remainingRootFilePath -Force
+            New-Item -ItemType 'File' -Path $remainingFooFilePath -Force
+            New-Item -ItemType 'File' -Path $remainingBarFilePath -Force
+
+            Mock Write-Host -ModuleName 'Lance'
+
+            Remove-BuildArtifact -Path $rootPath
+        }
+
+        It 'Deletes the root artifacts folder' {
+            $rootArtifactsPath | Should -Not -Exist
+        }
+
+        It 'Deletes the child artifacts folders' {
+            $fooArtifactsPath | Should -Not -Exist
+            $barArtifactsPath | Should -Not -Exist
+        }
+
+        It 'Writes deleted paths to the host' {
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $rootArtifactsPath" }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $fooArtifactsPath" }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $barArtifactsPath" }
+        }
+
+        It 'Does not delete other files' {
+            $remainingRootFilePath | Should -Exist
+            $remainingFooFilePath | Should -Exist
+            $remainingBarFilePath | Should -Exist
+        }
+
+        AfterEach {
+            Remove-Item -Path $rootPath -Recurse -Force
+        }
+    }
+
+    Context 'Bin' {
+        BeforeEach {
+            $rootPath = New-TemporaryDirectory
+            $rootBinPath = Join-Path -Path $rootPath -ChildPath 'bin'
+
+            $fooPath = Join-Path -Path $rootPath -ChildPath 'foo'
+            $fooBinPath = Join-Path -Path $fooPath -ChildPath 'bin'
+
+            $barPath = Join-Path -Path $rootPath -ChildPath 'bar'
+            $barBinPath = Join-Path -Path $barPath -ChildPath 'bin'
+
+            New-Item -ItemType 'File' -Path (Join-Path -Path $rootBinPath -ChildPath '1.txt') -Force
+            New-Item -ItemType 'File' -Path (Join-Path -Path $fooBinPath -ChildPath '2.txt') -Force
+            New-Item -ItemType 'File' -Path (Join-Path -Path $barBinPath -ChildPath '3.txt') -Force
+
+            $remainingRootFilePath = Join-Path -Path $rootPath -ChildPath '4.txt'
+            $remainingFooFilePath = Join-Path -Path $fooPath -ChildPath '5.txt'
+            $remainingBarFilePath = Join-Path -Path $barPath -ChildPath '6.txt'
+            New-Item -ItemType 'File' -Path $remainingRootFilePath -Force
+            New-Item -ItemType 'File' -Path $remainingFooFilePath -Force
+            New-Item -ItemType 'File' -Path $remainingBarFilePath -Force
+
+            Mock Write-Host -ModuleName 'Lance'
+
+            Remove-BuildArtifact -Path $rootPath
+        }
+
+        It 'Deletes the root bin folder' {
+            $rootBinPath | Should -Not -Exist
+        }
+
+        It 'Deletes the child bin folders' {
+            $fooBinPath | Should -Not -Exist
+            $barBinPath | Should -Not -Exist
+        }
+
+        It 'Writes deleted paths to the host' {
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $rootBinPath" }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $fooBinPath" }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $barBinPath" }
+        }
+
+        It 'Does not delete other files' {
+            $remainingRootFilePath | Should -Exist
+            $remainingFooFilePath | Should -Exist
+            $remainingBarFilePath | Should -Exist
+        }
+
+        AfterEach {
+            Remove-Item -Path $rootPath -Recurse -Force
+        }
+    }
+
+    Context 'Obj' {
+        BeforeEach {
+            $rootPath = New-TemporaryDirectory
+            $rootObjPath = Join-Path -Path $rootPath -ChildPath 'obj'
+
+            $fooPath = Join-Path -Path $rootPath -ChildPath 'foo'
+            $fooObjPath = Join-Path -Path $fooPath -ChildPath 'obj'
+
+            $barPath = Join-Path -Path $rootPath -ChildPath 'bar'
+            $barObjPath = Join-Path -Path $barPath -ChildPath 'obj'
+
+            New-Item -ItemType 'File' -Path (Join-Path -Path $rootObjPath -ChildPath '1.txt') -Force
+            New-Item -ItemType 'File' -Path (Join-Path -Path $fooObjPath -ChildPath '2.txt') -Force
+            New-Item -ItemType 'File' -Path (Join-Path -Path $barObjPath -ChildPath '3.txt') -Force
+
+            $remainingRootFilePath = Join-Path -Path $rootPath -ChildPath '4.txt'
+            $remainingFooFilePath = Join-Path -Path $fooPath -ChildPath '5.txt'
+            $remainingBarFilePath = Join-Path -Path $barPath -ChildPath '6.txt'
+            New-Item -ItemType 'File' -Path $remainingRootFilePath -Force
+            New-Item -ItemType 'File' -Path $remainingFooFilePath -Force
+            New-Item -ItemType 'File' -Path $remainingBarFilePath -Force
+
+            Mock Write-Host -ModuleName 'Lance'
+
+            Remove-BuildArtifact -Path $rootPath
+        }
+
+        It 'Deletes the root obj folder' {
+            $rootObjPath | Should -Not -Exist
+        }
+
+        It 'Deletes the child obj folders' {
+            $fooObjPath | Should -Not -Exist
+            $barObjPath | Should -Not -Exist
+        }
+
+        It 'Writes deleted paths to the host' {
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $rootObjPath" }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $fooObjPath" }
+            Should -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $barObjPath" }
+        }
+
+        It 'Does not delete other files' {
+            $remainingRootFilePath | Should -Exist
+            $remainingFooFilePath | Should -Exist
+            $remainingBarFilePath | Should -Exist
+        }
+
+        AfterEach {
+            Remove-Item -Path $rootPath -Recurse -Force
+        }
+    }
+
+    Context 'WhatIf' {
+        BeforeEach {
+            $rootPath = New-TemporaryDirectory
+            $artifactsPath = Join-Path -Path $rootPath -ChildPath 'artifacts'
+            $binPath = Join-Path -Path $rootPath -ChildPath 'bin'
+            $objPath = Join-Path -Path $rootPath -ChildPath 'obj'
+
+            New-Item -ItemType 'Directory' -Path $artifactsPath -Force
+            New-Item -ItemType 'Directory' -Path $binPath -Force
+            New-Item -ItemType 'Directory' -Path $objPath -Force
+
+            Mock Write-Host -ModuleName 'Lance'
+
+            Remove-BuildArtifact -Path $rootPath -WhatIf
+        }
+
+        It 'Does not delete anything' {
+            $artifactsPath | Should -Exist
+            $binPath | Should -Exist
+            $objPath | Should -Exist
+        }
+
+        It 'Does not write deleted paths to the host' {
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $artifactsPath" }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $binPath" }
+            Should -Not -Invoke -Command Write-Host -ModuleName 'Lance' -ParameterFilter { $Object -eq "Removing $objPath" }
+        }
+
+        AfterEach {
+            Remove-Item -Path $rootPath -Recurse -Force
+        }
+    }
+}

--- a/tests/public/Write-GitRepositoryDetail.Tests.ps1
+++ b/tests/public/Write-GitRepositoryDetail.Tests.ps1
@@ -1,9 +1,5 @@
 BeforeAll {
-    function New-TemporaryDirectory {
-        $path = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (New-Guid).Guid
-        New-Item -ItemType Directory -Path $path > $null
-        $path
-    }
+    . $PSScriptRoot/../testing/New-TemporaryDirectory.ps1
 
     # Setup remote repository.
     $remoteTemplatePath = New-TemporaryDirectory

--- a/tests/testing/New-TemporaryDirectory.ps1
+++ b/tests/testing/New-TemporaryDirectory.ps1
@@ -1,0 +1,9 @@
+function New-TemporaryDirectory {
+    [CmdletBinding()]
+    param()
+    process {
+        $path = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (New-Guid).Guid
+        New-Item -ItemType Directory -Path $path > $null
+        $path
+    }
+}


### PR DESCRIPTION
Add the Remove-BuildArtifact function, aliased as superclean, to allow for build artifact directories to be recursively deleted.