### PR TITLE
Fix upgrade issues

### DIFF
--- a/src/Lance.psd1
+++ b/src/Lance.psd1
@@ -22,7 +22,7 @@
     VariablesToExport = 'Lance'
     PrivateData = @{
         PSData = @{
-            Prerelease = 'preview6'
+            Prerelease = 'preview7'
             ReleaseNotes = 'https://raw.githubusercontent.com/lancra/pwsh/main/CHANGELOG.md'
             LicenseUri = 'https://raw.githubusercontent.com/lancra/pwsh/main/LICENSE'
             ProjectUri = 'https://github.com/lancra/pwsh'

--- a/src/public/Get-DotnetOutdatedPackage.ps1
+++ b/src/public/Get-DotnetOutdatedPackage.ps1
@@ -32,7 +32,9 @@ function Get-DotnetOutdatedPackage {
         $letterIdProvider = [LetterIdProvider]::new()
     }
     process {
-        $packagesResult = dotnet list $Path package --outdated --format json | ConvertFrom-Json
+        # The list command does not operate as expected with the .NET 8 upgrade, so the absolute path is used instead.
+        $absolutePath = (Resolve-Path -Path $Path).Path
+        $packagesResult = dotnet list $absolutePath package --outdated --format json | ConvertFrom-Json
 
         # Projects are included in the output, whether or not they have any outdated packages. This allows affected projects to be
         # flagged for inclusion in this output.

--- a/src/public/Get-DotnetTargetFramework.ps1
+++ b/src/public/Get-DotnetTargetFramework.ps1
@@ -57,7 +57,8 @@ function Get-DotnetTargetFramework {
             'netstandard2.0', # .NET Standard for .NET Core & .NET Framework
             'netstandard2.1', # .NET Standard for .NET Core Only
             'net6.0*', # LTS until 2024-11-12
-            'net7.0*' # STS until 2024-05-14
+            'net7.0*', # STS until 2024-05-14
+            'net8.0*' # LTS until 2026-11-10
         )
 
         $supportedVersionAggregatePattern = Join-String -InputObject $supportedVersionPatterns -Separator '|'

--- a/src/public/Invoke-SubDirectoryGitCommand.ps1
+++ b/src/public/Invoke-SubDirectoryGitCommand.ps1
@@ -61,7 +61,7 @@ function Invoke-SubDirectoryGitCommand {
                 Write-GitRepositoryDetail -Path $_.FullName -NoHead:$NoHead -NoAheadBehind:$NoAheadBehind
 
                 $trimmedCommand = $Command.ToString().Trim()
-                if ($trimmedCommand -like 'branch-current*' -and -not $NoHead) {
+                if ($trimmedCommand -like 'noop*') {
                     # Do not show the current branch via the provided command since it is displayed along with the directory name.
                     return
                 }

--- a/tests/Help.Tests.ps1
+++ b/tests/Help.Tests.ps1
@@ -18,6 +18,7 @@ BeforeDiscovery {
                 'OutBuffer',
                 'OutVariable',
                 'PipelineVariable',
+                'ProgressAction',
                 'Verbose',
                 'WarningAction',
                 'WarningVariable',

--- a/tests/public/Get-DotnetOutdatedPackage.Tests.ps1
+++ b/tests/public/Get-DotnetOutdatedPackage.Tests.ps1
@@ -9,13 +9,15 @@ BeforeAll {
             return Get-Content -Path $outputPath
         }
     }
+
+    $script:path = Resolve-Path .
 }
 
 Describe 'References' {
     Context 'Single Version, Single Project' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'single-version-single-project' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             $writeHostInvocations = [System.Collections.Generic.List[string]]::new()
@@ -38,7 +40,7 @@ Describe 'References' {
     Context 'Single Version, Multi Project' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'single-version-multi-project' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             $writeHostInvocations = [System.Collections.Generic.List[string]]::new()
@@ -62,7 +64,7 @@ Describe 'References' {
     Context 'Multi Version, Single Project' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'multi-version-single-project' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             $writeHostInvocations = [System.Collections.Generic.List[string]]::new()
@@ -87,7 +89,7 @@ Describe 'References' {
     Context 'Multi Version, Multi Project' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'multi-version-multi-project' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             $writeHostInvocations = [System.Collections.Generic.List[string]]::new()
@@ -115,7 +117,7 @@ Describe 'References' {
     Context 'No Version, Multi Project' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'no-version-multi-project' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             $writeHostInvocations = [System.Collections.Generic.List[string]]::new()
@@ -134,7 +136,7 @@ Describe 'Sorting' {
     Context 'Versions' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'version-sorting' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             $writeHostInvocations = [System.Collections.Generic.List[string]]::new()
@@ -171,7 +173,7 @@ Describe 'Sorting' {
     Context 'Projects' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'project-sorting' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             $writeHostInvocations = [System.Collections.Generic.List[string]]::new()
@@ -204,7 +206,7 @@ Describe 'Coloring' {
     Context 'Versions' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'version-sorting' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             Mock Write-Host -ModuleName Lance
@@ -224,7 +226,7 @@ Describe 'Coloring' {
     Context 'Projects' {
         BeforeEach {
             Mock dotnet { Get-FakeOutput -OutputFileName 'project-sorting' } -ModuleName Lance -ParameterFilter {
-                "$args" -eq 'list . package --outdated --format json'
+                "$args" -eq "list $path package --outdated --format json"
             }
 
             Mock Write-Host -ModuleName Lance

--- a/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
+++ b/tests/public/Invoke-SubDirectoryGitCommand.Tests.ps1
@@ -65,14 +65,9 @@ Describe 'Command Execution' {
             Should -Invoke 'git' -ModuleName Lance -ParameterFilter { "$args" -eq "-C $childPath pull" }
         }
 
-        It 'Skips current branch alias when head is shown' {
-            Invoke-SubDirectoryGitCommand -Command { branch-current } -Path $basePath
-            Should -Not -Invoke 'git' -ModuleName Lance -ParameterFilter { "$args" -eq "-C $childPath branch-current" }
-        }
-
-        It 'Executes current branch alias when head is not shown' {
-            Invoke-SubDirectoryGitCommand -Command { branch-current } -Path $basePath -NoHead
-            Should -Invoke 'git' -ModuleName Lance -ParameterFilter { "$args" -eq "-C $childPath branch-current" }
+        It 'Skips execution for noop command' {
+            Invoke-SubDirectoryGitCommand -Command { noop } -Path $basePath
+            Should -Not -Invoke 'git' -ModuleName Lance -ParameterFilter { "$args" -eq "-C $childPath noop" }
         }
     }
 


### PR DESCRIPTION
 * Fix tests broken by new common parameter in PowerShell v7.4.0.

 * Use absolute path for outdated packages as required by .NET 8.

 * Fix broken Git alias handling after rename.

 * Add .NET 8 as a supported target framework.